### PR TITLE
added option for disallowing system groovy script

### DIFF
--- a/src/main/java/jp/ikedam/jenkins/plugins/extensible_choice_parameter/ExtensibleChoiceConfig.java
+++ b/src/main/java/jp/ikedam/jenkins/plugins/extensible_choice_parameter/ExtensibleChoiceConfig.java
@@ -1,0 +1,33 @@
+package jp.ikedam.jenkins.plugins.extensible_choice_parameter;
+
+import hudson.Extension;
+import hudson.model.Descriptor;
+import jenkins.model.GlobalConfiguration;
+import net.sf.json.JSONObject;
+
+import org.kohsuke.stapler.StaplerRequest;
+
+@Extension
+public class ExtensibleChoiceConfig extends GlobalConfiguration
+{
+	private boolean disallowSystemGroovyScript;
+	public ExtensibleChoiceConfig()
+	{
+		load();
+	}
+	
+	public boolean getDisallowSystemGroovyScript()
+	{
+		return this.disallowSystemGroovyScript;
+	}
+	
+	@Override
+	public boolean configure(StaplerRequest req, JSONObject json) throws FormException
+	{
+		json = json.getJSONObject("extensibleChoiceParameter");
+		disallowSystemGroovyScript = json.getBoolean("disallowSystemGroovyScript");
+		req.bindJSON(this, json.getJSONObject("extensibleChoiceParameter"));
+		save();
+		return true;
+	}
+}

--- a/src/main/java/jp/ikedam/jenkins/plugins/extensible_choice_parameter/ExtensibleChoiceParameterDefinition.java
+++ b/src/main/java/jp/ikedam/jenkins/plugins/extensible_choice_parameter/ExtensibleChoiceParameterDefinition.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Pattern;
 
+import jenkins.model.GlobalConfiguration;
 import jenkins.model.Jenkins;
 import hudson.Extension;
 import hudson.DescriptorExtensionList;
@@ -43,6 +44,7 @@ import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
+
 import net.sf.json.JSONObject;
 
 /**
@@ -167,8 +169,22 @@ public class ExtensibleChoiceParameterDefinition extends SimpleParameterDefiniti
          */
         public DescriptorExtensionList<ChoiceListProvider,Descriptor<ChoiceListProvider>> getChoiceListProviderList()
         {
-            return ChoiceListProvider.all();
+        	return ChoiceListProvider.all();
         }
+        			
+        	public boolean getDisallowSystemGroovyScript()
+        	{
+        		ExtensibleChoiceConfig config = GlobalConfiguration.all().get(ExtensibleChoiceConfig.class);
+            	boolean disallowSystemGroovyScript = config.getDisallowSystemGroovyScript();
+            	
+        		return disallowSystemGroovyScript;
+        	}
+        	
+        	public String getSystemCommandName()
+        	{
+        		return Messages._SystemGroovyChoiceListProvider_DisplayName().toString();
+        	}
+        
         
         public FormValidation doCheckName(@QueryParameter String name){
             if(StringUtils.isBlank(name))

--- a/src/main/resources/jp/ikedam/jenkins/plugins/extensible_choice_parameter/ExtensibleChoiceConfig/config.jelly
+++ b/src/main/resources/jp/ikedam/jenkins/plugins/extensible_choice_parameter/ExtensibleChoiceConfig/config.jelly
@@ -1,0 +1,9 @@
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+
+  <f:section title="${%Extensible Choice Parameter}" name="extensibleChoiceParameter">
+      <f:entry title="${%Disallow System Groovy Script}" field="disallowSystemGroovyScript">
+        <f:checkbox/>
+      </f:entry>
+  </f:section>
+
+</j:jelly>

--- a/src/main/resources/jp/ikedam/jenkins/plugins/extensible_choice_parameter/ExtensibleChoiceParameterDefinition/config.jelly
+++ b/src/main/resources/jp/ikedam/jenkins/plugins/extensible_choice_parameter/ExtensibleChoiceParameterDefinition/config.jelly
@@ -41,21 +41,52 @@ THE SOFTWARE.
                 var="choiceListProvider"
                 value="${curDescriptor==instance.choiceListProvider.descriptor?instance.choiceListProvider:null}"
             />
-            <f:dropdownListBlock
-                title="${curDescriptor.displayName}"
-                value="${loop.index}"
-                selected="${choiceListProvider != null}"
-                staplerClass="${curDescriptor.clazz.name}"
-            ><j:scope>
-                <!-- Shown only when corresponding ChoiceProvider is selected. -->
-                <j:set var="descriptor" value="${curDescriptor}" />
-                <j:set var="instance" value="${choiceListProvider}" />
-                <!--
-                    Call config.jelly of the ChoiceProvider subclass.
-                    Do nothing if config.jelly is not provided.
-                -->
-                <st:include page="config.jelly" class="${curDescriptor.clazz}" optional="${true}" />
-            </j:scope></f:dropdownListBlock>
+            
+            <j:choose>
+            	<j:when test="${ curDescriptor.displayName == descriptor.systemCommandName  }">
+            		<j:if test="${!descriptor.disallowSystemGroovyScript}">
+            			<f:dropdownListBlock
+		                title="${curDescriptor.displayName}"
+		                value="${loop.index}"
+		                selected="${choiceListProvider != null}"
+		                staplerClass="${curDescriptor.clazz.name}"
+		           		>
+		           		<j:scope>
+			                <!-- Shown only when corresponding ChoiceProvider is selected. -->
+			                <j:set var="descriptor" value="${curDescriptor}" />
+			                <j:set var="instance" value="${choiceListProvider}" />
+			                <!--
+			                    Call config.jelly of the ChoiceProvider subclass.
+			                    Do nothing if config.jelly is not provided.
+			                -->
+			                <st:include page="config.jelly" class="${curDescriptor.clazz}" optional="${true}" />
+		            	</j:scope>
+	            		</f:dropdownListBlock>
+            		</j:if>
+            	</j:when>
+            	<j:otherwise>
+            		<f:dropdownListBlock
+	                title="${curDescriptor.displayName}"
+	                value="${loop.index}"
+	                selected="${choiceListProvider != null}"
+	                staplerClass="${curDescriptor.clazz.name}"
+	           		>
+		           		<j:scope>
+			                <!-- Shown only when corresponding ChoiceProvider is selected. -->
+			                <j:set var="descriptor" value="${curDescriptor}" />
+			                <j:set var="instance" value="${choiceListProvider}" />
+			                <!--
+			                    Call config.jelly of the ChoiceProvider subclass.
+			                    Do nothing if config.jelly is not provided.
+			                -->
+			                <st:include page="config.jelly" class="${curDescriptor.clazz}" optional="${true}" />
+		            	</j:scope>
+	            	</f:dropdownListBlock>
+            	</j:otherwise>
+            </j:choose>
+
+            
+            
             </j:scope>
         </j:forEach>
     </f:dropdownList>


### PR DESCRIPTION
when using a permission model and an user has just the job configure and
job run permission the system groovy script choice parameter would allow
the user to bypass the permissions and do everything he wants via the
groovy script
this commit adds a checkbox in the global jenkins configuration to
disallow system groovy scripts as choice parameter