### PR TITLE
[JENKINS-29934] Fix UnsupportedOperationException with adding empty choice to file lists.

### DIFF
--- a/src/main/java/jp/ikedam/jenkins/plugins/extensible_choice_parameter/FilenameChoiceListProvider.java
+++ b/src/main/java/jp/ikedam/jenkins/plugins/extensible_choice_parameter/FilenameChoiceListProvider.java
@@ -295,29 +295,20 @@ public class FilenameChoiceListProvider extends ChoiceListProvider implements Se
             }
         case Directory:
             {
-                ret = Arrays.asList(ds.getIncludedDirectories());
+                ret = new ArrayList<String>(Arrays.asList(ds.getIncludedDirectories()));
                 break;
             }
         default:
             {
                 // case File:
-                ret = Arrays.asList(ds.getIncludedFiles());
+                ret = new ArrayList<String>(Arrays.asList(ds.getIncludedFiles()));
                 break;
             }
         }
         
         if(reverseOrder)
         {
-            try
-            {
-                Collections.reverse(ret);
-            }
-            catch(UnsupportedOperationException _)
-            {
-                // ret is immutable.
-                ret = new ArrayList<String>(ret);
-                Collections.reverse(ret);
-            }
+            Collections.reverse(ret);
         }
         
         if(emptyChoiceType == null)

--- a/src/test/java/jp/ikedam/jenkins/plugins/extensible_choice_parameter/FilenameChoiceListProviderSimpleTest.java
+++ b/src/test/java/jp/ikedam/jenkins/plugins/extensible_choice_parameter/FilenameChoiceListProviderSimpleTest.java
@@ -620,10 +620,7 @@ public class FilenameChoiceListProviderSimpleTest
                 List<String> expected = Arrays.asList(
                         "",
                         "dir2/dir3/test4.dat",
-                        "dir2/dir3",
-                        "dir2",
                         "dir1/test3.txt",
-                        "dir1",
                         "test2.dat",
                         "test1.txt"
                 );
@@ -631,7 +628,7 @@ public class FilenameChoiceListProviderSimpleTest
                         tempDir,
                         "**/*",
                         "",
-                        ScanType.FileAndDirectory,
+                        ScanType.File,
                         true,
                         EmptyChoiceType.AtTop
                 );
@@ -641,20 +638,16 @@ public class FilenameChoiceListProviderSimpleTest
             // Empty choice at the end and reversed.
             {
                 List<String> expected = Arrays.asList(
-                        "dir2/dir3/test4.dat",
                         "dir2/dir3",
                         "dir2",
-                        "dir1/test3.txt",
                         "dir1",
-                        "test2.dat",
-                        "test1.txt",
                         ""
                 );
                 List<String> fileList = FilenameChoiceListProviderForTest.getFileList(
                         tempDir,
                         "**/*",
                         "",
-                        ScanType.FileAndDirectory,
+                        ScanType.Directory,
                         true,
                         EmptyChoiceType.AtEnd
                 );


### PR DESCRIPTION
[JENKINS-29934](https://issues.jenkins-ci.org/browse/JENKINS-29934)