### PR TITLE
Exclude helptext with information about how to specify multiple patterns

### DIFF
--- a/src/main/resources/jp/ikedam/jenkins/plugins/extensible_choice_parameter/FilenameChoiceListProvider/help-excludePattern.html
+++ b/src/main/resources/jp/ikedam/jenkins/plugins/extensible_choice_parameter/FilenameChoiceListProvider/help-excludePattern.html
@@ -1,3 +1,6 @@
 <div>
 Specify patterns not to list (even specified in File Name Pattern field).
+Multiple patterns can be specified by separating with comma(,).
+Wildcard is available like '**/*.xml'.
+See <a href='http://ant.apache.org/manual/Types/fileset.html'>excludes attribute of Ant FileSet Type</a> for the exact format.
 </div>


### PR DESCRIPTION
Exclude helptext is missing information about how to specify multiple patterns