### PR TITLE
[JENKINS-37147] "Top Most Value" is replaced with an empty value when the page load is slow

### DIFF
--- a/src/main/java/jp/ikedam/jenkins/plugins/extensible_choice_parameter/GlobalTextareaChoiceListProvider.java
+++ b/src/main/java/jp/ikedam/jenkins/plugins/extensible_choice_parameter/GlobalTextareaChoiceListProvider.java
@@ -151,6 +151,15 @@ public class GlobalTextareaChoiceListProvider extends AddEditedChoiceListProvide
             return ret;
         }
         
+
+        /**
+         * @return the special value used for "No default choice" (use the top most)
+         */
+        public String getNoDefaultChoice()
+        {
+            return NoDefaultChoice;
+        }
+
         /**
          * Retrieve the set of choices entry by the name.
          * 

--- a/src/main/java/jp/ikedam/jenkins/plugins/extensible_choice_parameter/SystemGroovyChoiceListProvider.java
+++ b/src/main/java/jp/ikedam/jenkins/plugins/extensible_choice_parameter/SystemGroovyChoiceListProvider.java
@@ -149,7 +149,15 @@ public class SystemGroovyChoiceListProvider extends ChoiceListProvider
             
             return ret;
         }
-        
+
+        /**
+         * @return the special value used for "No default choice" (use the top most)
+         */
+        public String getNoDefaultChoice()
+        {
+            return NoDefaultChoice;
+        }
+
         public FormValidation doTest(StaplerRequest req, @QueryParameter String scriptText, @QueryParameter boolean usePredefinedVariables)
         {
             List<String> choices = null;

--- a/src/main/java/jp/ikedam/jenkins/plugins/extensible_choice_parameter/TextareaChoiceListProvider.java
+++ b/src/main/java/jp/ikedam/jenkins/plugins/extensible_choice_parameter/TextareaChoiceListProvider.java
@@ -93,6 +93,14 @@ public class TextareaChoiceListProvider extends AddEditedChoiceListProvider
             }
             return ret;
         }
+
+        /**
+         * @return the special value used for "No default choice" (use the top most)
+         */
+        public String getNoDefaultChoice()
+        {
+            return NoDefaultChoice;
+        }
     }
     
     private List<String> choiceList = null;

--- a/src/main/resources/jp/ikedam/jenkins/plugins/extensible_choice_parameter/GlobalTextareaChoiceListProvider/config.jelly
+++ b/src/main/resources/jp/ikedam/jenkins/plugins/extensible_choice_parameter/GlobalTextareaChoiceListProvider/config.jelly
@@ -32,7 +32,7 @@ THE SOFTWARE.
         <f:select />
     </f:entry>
     <f:entry title="${%Default Choice}" field="defaultChoice" help="/plugin/extensible-choice-parameter/help/defaultChoice.html">
-        <f:select />
+        <f:select default="${descriptor.noDefaultChoice}" />
     </f:entry>
     <m:addEditedValue />
 </j:jelly>

--- a/src/main/resources/jp/ikedam/jenkins/plugins/extensible_choice_parameter/SystemGroovyChoiceListProvider/config.jelly
+++ b/src/main/resources/jp/ikedam/jenkins/plugins/extensible_choice_parameter/SystemGroovyChoiceListProvider/config.jelly
@@ -36,6 +36,6 @@ THE SOFTWARE.
         with="scriptText,usePredefinedVariables"
     />
     <f:entry title="${%Default Choice}" field="defaultChoice" help="/plugin/extensible-choice-parameter/help/defaultChoice.html">
-        <f:select />
+        <f:select default="${descriptor.noDefaultChoice}" />
     </f:entry>
 </j:jelly>

--- a/src/main/resources/jp/ikedam/jenkins/plugins/extensible_choice_parameter/TextareaChoiceListProvider/config.jelly
+++ b/src/main/resources/jp/ikedam/jenkins/plugins/extensible_choice_parameter/TextareaChoiceListProvider/config.jelly
@@ -27,7 +27,7 @@ THE SOFTWARE.
         <f:textarea />
     </f:entry>
     <f:entry title="${%Default Choice}" field="defaultChoice" help="/plugin/extensible-choice-parameter/help/defaultChoice.html">
-        <f:select />
+        <f:select default="${descriptor.noDefaultChoice}" />
     </f:entry>
     <m:addEditedValue />
 </j:jelly>


### PR DESCRIPTION
[JENKINS-37147](https://issues.jenkins-ci.org/browse/JENKINS-37147)

"Top Most Value" is expressed as `null` on the memory.
It is expressed as a special string "###NODEFAULTCHOICE###" on HTML forms as HTML forms doesn't distinguish empty strings and `null`. That value is converted to `null` when serializing from form inputs.

Jenkins loads values for comboboxes dynamically with `Descriptor#doFillXxxxItems`.

Before completing loading values, Jenkins uses the value on the memory for the combobox.
When you save the form before completing loading values for comboboxes, `null` (not "###NODEFAULTCHOICE###"!) is used for the combobox value, and it is treated as an empty value.

Consequently, this happens: "Top Most Value" is replaced with an empty value when saving the configuration before completing loading the page. It often happens when the page load is slow.

This change fixes the problem by specifying the value used before loading values for comboboxes.

Adding `Thread.sleep(5000)` to `doFillDefaultChoiceItems` makes it easy to reproduce the problem.
On the other hands, it is really difficult to reproduce the problems in unit tests as htmlunit waits for completing loading pages.
So I tested this change manually:

|Provider                        |Value        |Before this change|After this change|
|:-------------------------------|:------------|:-----------------|:----------------|
|SystemGroovyChoiceListProvider  |(TopMost)    |(Blank value)     |(TopMost)        |
|SystemGroovyChoiceListProvider  |(Blank value)|(Blank value)     |(Blank value)    |
|GlobalTextareaChoiceListProvider|(TopMost)    |(Blank value)     |(TopMost)        |
|GlobalTextareaChoiceListProvider|(Blank value)|(Blank value)     |(Blank value)    |
|TextareaChoiceListProvider      |(TopMost)    |(Blank value)     |(TopMost)        |
|TextareaChoiceListProvider      |(Blank value)|(Blank value)     |(Blank value)    |
