### PR TITLE
[JENKINS-39647] IAE from getDefaultParameterValue

### DIFF
--- a/src/main/java/jp/ikedam/jenkins/plugins/extensible_choice_parameter/ExtensibleChoiceParameterDefinition.java
+++ b/src/main/java/jp/ikedam/jenkins/plugins/extensible_choice_parameter/ExtensibleChoiceParameterDefinition.java
@@ -445,9 +445,12 @@ public class ExtensibleChoiceParameterDefinition extends SimpleParameterDefiniti
     {
         ChoiceListProvider p = getEnabledChoiceListProvider();
         String defaultChoice = (p != null)?p.getDefaultChoice():null;
-        if(defaultChoice != null)
-        {
-            return createValue(defaultChoice);
+        if (defaultChoice != null) {
+            try {
+                return createValue(defaultChoice);
+            } catch (IllegalArgumentException x) { // JENKINS-39647
+                return null;
+            }
         }
         
         List<String> choiceList = getChoiceList();

--- a/src/main/java/jp/ikedam/jenkins/plugins/extensible_choice_parameter/ExtensibleChoiceParameterDefinition.java
+++ b/src/main/java/jp/ikedam/jenkins/plugins/extensible_choice_parameter/ExtensibleChoiceParameterDefinition.java
@@ -449,7 +449,7 @@ public class ExtensibleChoiceParameterDefinition extends SimpleParameterDefiniti
             try {
                 return createValue(defaultChoice);
             } catch (IllegalArgumentException x) { // JENKINS-39647
-                return null;
+                return new StringParameterValue(getName(), defaultChoice, getDescription());
             }
         }
         

--- a/src/test/java/jp/ikedam/jenkins/plugins/extensible_choice_parameter/ExtensibleChoiceParameterDefinitionJenkinsTest.java
+++ b/src/test/java/jp/ikedam/jenkins/plugins/extensible_choice_parameter/ExtensibleChoiceParameterDefinitionJenkinsTest.java
@@ -628,7 +628,7 @@ public class ExtensibleChoiceParameterDefinitionJenkinsTest
             job.save();
             
             j.assertBuildStatusSuccess(job.scheduleBuild2(0));
-            assertEquals("non-editable, not in choice", null, ceb.getEnvVars().get("test"));
+            assertEquals("non-editable, not in choice", "value4", ceb.getEnvVars().get("test"));
         }
     }
     
@@ -997,7 +997,7 @@ public class ExtensibleChoiceParameterDefinitionJenkinsTest
                     false,
                     description
             );
-            assertNull("Non-Editable, not in choices", target.getDefaultParameterValue());
+            assertEquals("Non-Editable, not in choices", new StringParameterValue(name, defaultChoice, description), target.getDefaultParameterValue());
         }
         
         // no choice is provided and non-editable. returns null.

--- a/src/test/java/jp/ikedam/jenkins/plugins/extensible_choice_parameter/ExtensibleChoiceParameterDefinitionJenkinsTest.java
+++ b/src/test/java/jp/ikedam/jenkins/plugins/extensible_choice_parameter/ExtensibleChoiceParameterDefinitionJenkinsTest.java
@@ -627,14 +627,8 @@ public class ExtensibleChoiceParameterDefinitionJenkinsTest
             job.getBuildersList().add(ceb);
             job.save();
             
-            try{
-                job.scheduleBuild2(job.getQuietPeriod()).get();
-                assertTrue("not reachable", false);
-            }
-            catch(IllegalArgumentException e)
-            {
-                assertTrue("non-editable, not in choice", true);
-            }
+            j.assertBuildStatusSuccess(job.scheduleBuild2(0));
+            assertEquals("non-editable, not in choice", null, ceb.getEnvVars().get("test"));
         }
     }
     
@@ -1003,15 +997,7 @@ public class ExtensibleChoiceParameterDefinitionJenkinsTest
                     false,
                     description
             );
-            try
-            {
-                assertEquals("Non-Editable, not in choices", new StringParameterValue(name, defaultChoice, description), target.getDefaultParameterValue());
-                assertTrue("Not reachable", false);
-            }
-            catch(IllegalArgumentException e)
-            {
-                assertTrue("Non-Editable, not in choices", true);
-            }
+            assertNull("Non-Editable, not in choices", target.getDefaultParameterValue());
         }
         
         // no choice is provided and non-editable. returns null.


### PR DESCRIPTION
[JENKINS-39647](https://issues.jenkins-ci.org/browse/JENKINS-39647)

You may only throw an `IllegalArgumentException` if an argument was actually provided! And the method this is overriding does not declare such an exception.

@reviewbybees