### PR TITLE
[FIXED JENKINS-39647] `getDefaultParameterValue` should not fail

### DIFF
--- a/src/main/java/jp/ikedam/jenkins/plugins/extensible_choice_parameter/ExtensibleChoiceParameterDefinition.java
+++ b/src/main/java/jp/ikedam/jenkins/plugins/extensible_choice_parameter/ExtensibleChoiceParameterDefinition.java
@@ -394,7 +394,11 @@ public class ExtensibleChoiceParameterDefinition extends SimpleParameterDefiniti
         if(!isEditable() && !getChoiceList().contains(value.value))
         {
             // Something strange!: Not editable and specified a value not in the choices.
-            throw new IllegalArgumentException("Illegal choice: " + value.value);
+            throw new IllegalArgumentException(String.format(
+                "Illegal choice '%s' in parameter '%s&",
+                value.value,
+                value.getName()
+            ));
         }
         return value;
     }
@@ -447,7 +451,12 @@ public class ExtensibleChoiceParameterDefinition extends SimpleParameterDefiniti
         String defaultChoice = (p != null)?p.getDefaultChoice():null;
         if(defaultChoice != null)
         {
-            return createValue(defaultChoice);
+            try {
+                return createValue(defaultChoice);
+            } catch (IllegalArgumentException e) {
+                LOGGER.log(Level.WARNING, "Illegal choice for the default value. Ignore and use the value in the top of the list instead.", e);
+                // pass through
+            }
         }
         
         List<String> choiceList = getChoiceList();

--- a/src/test/java/jp/ikedam/jenkins/plugins/extensible_choice_parameter/ExtensibleChoiceParameterDefinitionJenkinsTest.java
+++ b/src/test/java/jp/ikedam/jenkins/plugins/extensible_choice_parameter/ExtensibleChoiceParameterDefinitionJenkinsTest.java
@@ -613,6 +613,7 @@ public class ExtensibleChoiceParameterDefinitionJenkinsTest
         }
         
         // non-editable, not in choice
+        // The value on the top should be used.
         {
             ChoiceListProvider provider = new MockChoiceListProvider(Arrays.asList("value1", "value2", "value3"), "value4");
             ExtensibleChoiceParameterDefinition def = new ExtensibleChoiceParameterDefinition(
@@ -627,14 +628,8 @@ public class ExtensibleChoiceParameterDefinitionJenkinsTest
             job.getBuildersList().add(ceb);
             job.save();
             
-            try{
-                job.scheduleBuild2(job.getQuietPeriod()).get();
-                assertTrue("not reachable", false);
-            }
-            catch(IllegalArgumentException e)
-            {
-                assertTrue("non-editable, not in choice", true);
-            }
+            j.assertBuildStatusSuccess(job.scheduleBuild2(0));
+            assertEquals("value1", ceb.getEnvVars().get("test"));
         }
     }
     
@@ -994,6 +989,7 @@ public class ExtensibleChoiceParameterDefinitionJenkinsTest
         }
         
         // Non-editable, not in choices
+        // The value on the top should be used.
         {
             String defaultChoice = "value4";
             ChoiceListProvider provider = new MockChoiceListProvider(Arrays.asList("value1", "value2", "value3"), defaultChoice);
@@ -1003,15 +999,7 @@ public class ExtensibleChoiceParameterDefinitionJenkinsTest
                     false,
                     description
             );
-            try
-            {
-                assertEquals("Non-Editable, not in choices", new StringParameterValue(name, defaultChoice, description), target.getDefaultParameterValue());
-                assertTrue("Not reachable", false);
-            }
-            catch(IllegalArgumentException e)
-            {
-                assertTrue("Non-Editable, not in choices", true);
-            }
+            assertEquals(new StringParameterValue(name, "value1", description), target.getDefaultParameterValue());
         }
         
         // no choice is provided and non-editable. returns null.


### PR DESCRIPTION
[JENKINS-39647](https://issues.jenkins-ci.org/browse/JENKINS-39647)
Replace #27 

`getParameterValue` should not throw exceptions.
This happens when a value not in the choice list is defined as the default value
(e.g. by editing the choice list with a global choice).
Extensible-choice-parameter should return the value in the top of the list just like built-in choice parameter in these cases.