### PR TITLE
Fix findbug issues for `Jenkins.getInstance()`

### DIFF
--- a/src/main/java/jp/ikedam/jenkins/plugins/extensible_choice_parameter/ExtensibleChoiceParameterDefinition.java
+++ b/src/main/java/jp/ikedam/jenkins/plugins/extensible_choice_parameter/ExtensibleChoiceParameterDefinition.java
@@ -198,10 +198,14 @@ public class ExtensibleChoiceParameterDefinition extends SimpleParameterDefiniti
             if (staplerClazzName == null) {
                 throw new FormException("No $stapler nor stapler-class is specified", fieldName);
             }
+            Jenkins jenkins = Jenkins.getInstance();
+            if (jenkins == null) {
+                throw new IllegalStateException("Jenkins instance is unavailable.");
+            }
             try {
                 @SuppressWarnings("unchecked")
-                Class<? extends T> staplerClass = (Class<? extends T>)Jenkins.getInstance().getPluginManager().uberClassLoader.loadClass(staplerClazzName);
-                Descriptor<?> d = Jenkins.getInstance().getDescriptorOrDie(staplerClass);
+                Class<? extends T> staplerClass = (Class<? extends T>)jenkins.getPluginManager().uberClassLoader.loadClass(staplerClazzName);
+                Descriptor<?> d = jenkins.getDescriptorOrDie(staplerClass);
                 
                 @SuppressWarnings("unchecked")
                 T instance = (T)d.newInstance(req, formData);

--- a/src/main/java/jp/ikedam/jenkins/plugins/extensible_choice_parameter/FilenameChoiceListProvider.java
+++ b/src/main/java/jp/ikedam/jenkins/plugins/extensible_choice_parameter/FilenameChoiceListProvider.java
@@ -121,8 +121,11 @@ public class FilenameChoiceListProvider extends ChoiceListProvider
         {
             return rawDir;
         }
-        
-        return new File(Jenkins.getInstance().getRootDir(), baseDirPath);
+        Jenkins jenkins = Jenkins.getInstance();
+        if (jenkins == null) {
+            throw new IllegalStateException("Jenkins instance is unavailable.");
+        }
+        return new File(jenkins.getRootDir(), baseDirPath);
     }
     
     /**

--- a/src/main/java/jp/ikedam/jenkins/plugins/extensible_choice_parameter/SystemGroovyChoiceListProvider.java
+++ b/src/main/java/jp/ikedam/jenkins/plugins/extensible_choice_parameter/SystemGroovyChoiceListProvider.java
@@ -273,7 +273,11 @@ public class SystemGroovyChoiceListProvider extends ChoiceListProvider
 
     private static List<String> runScript(SecureGroovyScript groovyScript, boolean usePredefinedVariables, Job<?,?> project) throws Exception {
         // see RemotingDiagnostics.Script
-        ClassLoader cl = Jenkins.getInstance().getPluginManager().uberClassLoader;
+        Jenkins jenkins = Jenkins.getInstance();
+        if (jenkins == null) {
+            throw new IllegalStateException("Jenkins instance is unavailable.");
+        }
+        ClassLoader cl = jenkins.getPluginManager().uberClassLoader;
 
         if (cl == null) {
             cl = Thread.currentThread().getContextClassLoader();


### PR DESCRIPTION
`CheckForNull` annotates `Jenkins.getInstance()` since 1.557 and findbugs warns that since 1.4.0.
Just throw `IllegalStateException` for `null` just as the latest (or future) `Jenkins.getInstance()`.
