### PR TITLE
[JENKINS-42903] Sanitize names and descriptions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,12 @@
       <version>1.1</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>antisamy-markup-formatter</artifactId>
+      <version>1.1</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   
   <build>

--- a/src/main/resources/jp/ikedam/jenkins/plugins/extensible_choice_parameter/ExtensibleChoiceParameterDefinition/config.jelly
+++ b/src/main/resources/jp/ikedam/jenkins/plugins/extensible_choice_parameter/ExtensibleChoiceParameterDefinition/config.jelly
@@ -30,7 +30,7 @@ THE SOFTWARE.
         <f:textbox />
     </f:entry>
     <f:entry title="${%Description}" field="description" help="/help/parameter/description.html">
-        <f:textarea />
+        <f:textarea previewEndpoint="/markupFormatter/previewDescription" />
     </f:entry>
     <f:dropdownDescriptorSelector title="${%Choice Provider}" field="choiceListProvider" descriptors="${descriptor.enabledChoiceListProviderList}" />
     <f:entry title="${%Editable}" field="editable">

--- a/src/main/resources/jp/ikedam/jenkins/plugins/extensible_choice_parameter/ExtensibleChoiceParameterDefinition/index.jelly
+++ b/src/main/resources/jp/ikedam/jenkins/plugins/extensible_choice_parameter/ExtensibleChoiceParameterDefinition/index.jelly
@@ -28,7 +28,8 @@ THE SOFTWARE.
         In this view, the fields are not managed in Descriable/Descriptor framework,
         and results in not using /lib/form taglibs, but writing HTML input tags directory.
     -->
-    <f:entry title="${it.name}" description="${it.description}">
+    <j:set var="escapeEntryTitleAndDescription" value="false" />
+    <f:entry title="${h.escape(it.name)}" description="${it.formattedDescription}">
         <div name="parameter" description="${it.description}">
             <input type="hidden" name="name" value="${it.name}" />
             <j:scope>


### PR DESCRIPTION
[JENKINS-42903](https://issues.jenkins-ci.org/browse/JENKINS-42903)

HTML texts in descriptions of matrix-combinations-parameters get escaped since Jenkins-2.32.2.
This is caused for the fix for SECURITY-353.

Related commits:
* jenkinsci/jenkins@b561ca5696f12d8e017f79cc2080c394c6710719
* jenkinsci/jenkins@0b471b7b693eb370c52c82382257419a07171f93

This means matrix-combinations-parameter plugin cause XSS when used with Jenkins < 2.32.2.
This requests applies appropriate HTML escaping.
