### PR TITLE
[JENKINS-49017] - Whitelist java.util.RandomAccessSublist to make the plugin compatible with Jenkins 2.102+

### DIFF
--- a/src/main/resources/META-INF/hudson.remoting.ClassFilter
+++ b/src/main/resources/META-INF/hudson.remoting.ClassFilter
@@ -1,0 +1,1 @@
+java.util.RandomAccessSubList


### PR DESCRIPTION
This type is being returned by `ArrayList#sublist()` being used in the plugin.
Seems to be a valid use-case.

@reviewbybees @jglick @ikedam 