### PR TITLE
[JENKINS-49210] [JENKINS-49017] Do not use RandomAccessSubList

### DIFF
--- a/src/main/java/jp/ikedam/jenkins/plugins/extensible_choice_parameter/utility/TextareaStringListUtility.java
+++ b/src/main/java/jp/ikedam/jenkins/plugins/extensible_choice_parameter/utility/TextareaStringListUtility.java
@@ -88,7 +88,10 @@ public class TextareaStringListUtility
             // The last empty line will be ignored.
             // The list object returned from asList() does not support remove,
             // so use subList().
-            stringList = stringList.subList(0, stringList.size() - 1);
+            // And recreate ArrayList, as subList() returns java.util.RandomAccessSubList,
+            // which results complicated output in XStream (that is, complicated config.xml),
+            // and is not whitelisted in JEP-200.
+            stringList = new ArrayList<String>(stringList.subList(0, stringList.size() - 1));
         }
         
         return stringList;

--- a/src/main/resources/META-INF/hudson.remoting.ClassFilter
+++ b/src/main/resources/META-INF/hudson.remoting.ClassFilter
@@ -1,1 +1,2 @@
+# For backward compatibility with 1.4.2-
 java.util.RandomAccessSubList

--- a/src/test/java/jp/ikedam/jenkins/plugins/extensible_choice_parameter/ExtensibleChoiceParameterDefinitionJenkinsTest.java
+++ b/src/test/java/jp/ikedam/jenkins/plugins/extensible_choice_parameter/ExtensibleChoiceParameterDefinitionJenkinsTest.java
@@ -49,7 +49,6 @@ import hudson.util.FormValidation;
 import net.sf.json.JSONObject;
 
 import org.apache.commons.lang.StringUtils;
-import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule.WebClient;
@@ -1183,4 +1182,5 @@ public class ExtensibleChoiceParameterDefinitionJenkinsTest
 
         assertNotNull(page.getElementById("test-expected"));
         assertNull(page.getElementById("test-not-expected"));
-    }}
+    }
+}

--- a/src/test/java/jp/ikedam/jenkins/plugins/extensible_choice_parameter/IntegrationTest.java
+++ b/src/test/java/jp/ikedam/jenkins/plugins/extensible_choice_parameter/IntegrationTest.java
@@ -1,0 +1,55 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2018 IKEDA Yasuyuki
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package jp.ikedam.jenkins.plugins.extensible_choice_parameter;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.recipes.LocalData;
+
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.TaskListener;
+
+/**
+ * Tests using several {@link ChoiceListProvider}s
+ */
+public class IntegrationTest {
+    @Rule
+    public ExtensibleChoiceParameterJenkinsRule j = new ExtensibleChoiceParameterJenkinsRule();
+
+    @Test
+    @Issue("JENKINS-49210")
+    @LocalData
+    // This test explains why we need hudson.remoting.ClassFilter file with Jenkins 2.102+
+    public void testJEP200() throws Exception {
+        FreeStyleProject p = j.jenkins.getItemByFullName("JobWithSublist", FreeStyleProject.class);
+        FreeStyleBuild b = j.assertBuildStatusSuccess(p.scheduleBuild2(0));
+        assertEquals("ChoiceWithSublist1", b.getEnvironment(TaskListener.NULL).get("ChoiceWithSublist"));
+        assertEquals("GlobalChoiceWithSublist1", b.getEnvironment(TaskListener.NULL).get("GlobalChoiceWithSublist"));
+    }
+}

--- a/src/test/resources/jp/ikedam/jenkins/plugins/extensible_choice_parameter/IntegrationTest/testJEP200/config.xml
+++ b/src/test/resources/jp/ikedam/jenkins/plugins/extensible_choice_parameter/IntegrationTest/testJEP200/config.xml
@@ -1,0 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<hudson>
+  <version>1.580.1</version>
+</hudson>

--- a/src/test/resources/jp/ikedam/jenkins/plugins/extensible_choice_parameter/IntegrationTest/testJEP200/jobs/JobWithSublist/config.xml
+++ b/src/test/resources/jp/ikedam/jenkins/plugins/extensible_choice_parameter/IntegrationTest/testJEP200/jobs/JobWithSublist/config.xml
@@ -1,0 +1,49 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project>
+  <actions/>
+  <description></description>
+  <keepDependencies>false</keepDependencies>
+  <properties>
+    <hudson.model.ParametersDefinitionProperty>
+      <parameterDefinitions>
+        <jp.ikedam.jenkins.plugins.extensible__choice__parameter.ExtensibleChoiceParameterDefinition plugin="extensible-choice-parameter@1.4.2">
+          <name>ChoiceWithSublist</name>
+          <description></description>
+          <editable>false</editable>
+          <choiceListProvider class="jp.ikedam.jenkins.plugins.extensible_choice_parameter.TextareaChoiceListProvider">
+            <choiceList class="java.util.RandomAccessSubList">
+              <l class="java.util.Arrays$ArrayList">
+                <a class="string-array">
+                  <string>ChoiceWithSublist1</string>
+                  <string>ChoiceWithSublist2</string>
+                  <string>ChoiceWithSublist3</string>
+                  <string></string>
+                </a>
+              </l>
+              <offset>0</offset>
+              <size>3</size>
+            </choiceList>
+          </choiceListProvider>
+        </jp.ikedam.jenkins.plugins.extensible__choice__parameter.ExtensibleChoiceParameterDefinition>
+        <jp.ikedam.jenkins.plugins.extensible__choice__parameter.ExtensibleChoiceParameterDefinition plugin="extensible-choice-parameter@1.4.3-SNAPSHOT">
+          <name>GlobalChoiceWithSublist</name>
+          <description></description>
+          <editable>false</editable>
+          <choiceListProvider class="jp.ikedam.jenkins.plugins.extensible_choice_parameter.GlobalTextareaChoiceListProvider">
+            <name>GlobalChoiceWithSublist</name>
+          </choiceListProvider>
+        </jp.ikedam.jenkins.plugins.extensible__choice__parameter.ExtensibleChoiceParameterDefinition>
+      </parameterDefinitions>
+    </hudson.model.ParametersDefinitionProperty>
+  </properties>
+  <scm class="hudson.scm.NullSCM"/>
+  <canRoam>true</canRoam>
+  <disabled>false</disabled>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <triggers/>
+  <concurrentBuild>false</concurrentBuild>
+  <builders/>
+  <publishers/>
+  <buildWrappers/>
+</project>

--- a/src/test/resources/jp/ikedam/jenkins/plugins/extensible_choice_parameter/IntegrationTest/testJEP200/jp.ikedam.jenkins.plugins.extensible_choice_parameter.GlobalTextareaChoiceListProvider.xml
+++ b/src/test/resources/jp/ikedam/jenkins/plugins/extensible_choice_parameter/IntegrationTest/testJEP200/jp.ikedam.jenkins.plugins.extensible_choice_parameter.GlobalTextareaChoiceListProvider.xml
@@ -1,0 +1,21 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<jp.ikedam.jenkins.plugins.extensible__choice__parameter.GlobalTextareaChoiceListProvider_-DescriptorImpl plugin="extensible-choice-parameter@1.4.2">
+  <choiceListEntryList>
+    <jp.ikedam.jenkins.plugins.extensible__choice__parameter.GlobalTextareaChoiceListEntry>
+      <name>GlobalChoiceWithSublist</name>
+      <choiceList class="java.util.RandomAccessSubList">
+        <l class="java.util.Arrays$ArrayList">
+          <a class="string-array">
+            <string>GlobalChoiceWithSublist1</string>
+            <string>GlobalChoiceWithSublist2</string>
+            <string>GlobalChoiceWithSublist3</string>
+            <string></string>
+          </a>
+        </l>
+        <offset>0</offset>
+        <size>3</size>
+      </choiceList>
+      <allowAddEditedValue>false</allowAddEditedValue>
+    </jp.ikedam.jenkins.plugins.extensible__choice__parameter.GlobalTextareaChoiceListEntry>
+  </choiceListEntryList>
+</jp.ikedam.jenkins.plugins.extensible__choice__parameter.GlobalTextareaChoiceListProvider_-DescriptorImpl>


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-49210

* As fix for JEP-200.
    * Unfortunately I have to continue to allow RandomAccessSubList for configurations save with 1.4.2-.
* To simplify xml.

