### PR TITLE
[JENKINS-50315] [JENKINS-22316] Introduce `editableType`

### DIFF
--- a/src/main/resources/jp/ikedam/jenkins/plugins/extensible_choice_parameter/ExtensibleChoiceParameterDefinition/config.jelly
+++ b/src/main/resources/jp/ikedam/jenkins/plugins/extensible_choice_parameter/ExtensibleChoiceParameterDefinition/config.jelly
@@ -33,7 +33,9 @@ THE SOFTWARE.
         <f:textarea previewEndpoint="/markupFormatter/previewDescription" />
     </f:entry>
     <f:dropdownDescriptorSelector title="${%Choice Provider}" field="choiceListProvider" descriptors="${descriptor.enabledChoiceListProviderList}" />
-    <f:entry title="${%Editable}" field="editable">
-        <f:checkbox />
-    </f:entry>
+    <f:optionalBlock field="editable" inline="true" title="${%Editable}">
+        <f:entry title="${%Choices for input value}" field="editableType">
+            <f:enum>${it.displayName}</f:enum>
+        </f:entry>
+    </f:optionalBlock>
 </j:jelly>

--- a/src/main/resources/jp/ikedam/jenkins/plugins/extensible_choice_parameter/ExtensibleChoiceParameterDefinition/config_ja.properties
+++ b/src/main/resources/jp/ikedam/jenkins/plugins/extensible_choice_parameter/ExtensibleChoiceParameterDefinition/config_ja.properties
@@ -28,3 +28,5 @@ Description=\u8aac\u660e
 Choice\ Provider=\u9078\u629e\u80a2\u306e\u53d6\u5f97\u65b9\u6cd5
 # Editable=編集可能にする
 Editable=\u7de8\u96c6\u53ef\u80fd\u306b\u3059\u308b
+# Choices\ for\ input\ value=入力値に対する選択肢の表示
+Choices\ for\ input\ value=\u5165\u529b\u5024\u306b\u5bfe\u3059\u308b\u9078\u629e\u80a2\u306e\u8868\u793a

--- a/src/main/resources/jp/ikedam/jenkins/plugins/extensible_choice_parameter/ExtensibleChoiceParameterDefinition/index.jelly
+++ b/src/main/resources/jp/ikedam/jenkins/plugins/extensible_choice_parameter/ExtensibleChoiceParameterDefinition/index.jelly
@@ -39,6 +39,7 @@ THE SOFTWARE.
                     field="value"
                     items="${it.choiceList}"
                     editable="${it.editable}"
+                    editableType="${it.editableType.name()}"
                 />
             </j:scope>
         </div>

--- a/src/main/resources/jp/ikedam/jenkins/plugins/extensible_choice_parameter/Messages.properties
+++ b/src/main/resources/jp/ikedam/jenkins/plugins/extensible_choice_parameter/Messages.properties
@@ -44,3 +44,5 @@ AddEditedChoiceListProvider.WhenToAdd.Triggered=triggered
 AddEditedChoiceListProvider.WhenToAdd.Completed=completed
 AddEditedChoiceListProvider.WhenToAdd.CompletedStable=completed stable
 AddEditedChoiceListProvider.WhenToAdd.CompletedUnstable=completed stable or unstable
+ExtensibleChoiceParameterDefinition.EditableType.NoFilter=Display all choices
+ExtensibleChoiceParameterDefinition.EditableType.Filter=Display only matching choices

--- a/src/main/resources/jp/ikedam/jenkins/plugins/extensible_choice_parameter/Messages_ja.properties
+++ b/src/main/resources/jp/ikedam/jenkins/plugins/extensible_choice_parameter/Messages_ja.properties
@@ -69,3 +69,7 @@ AddEditedChoiceListProvider.WhenToAdd.Completed=\u30d3\u30eb\u30c9\u5b8c\u4e86\u
 AddEditedChoiceListProvider.WhenToAdd.CompletedStable=\u30d3\u30eb\u30c9\u6210\u529f\u6642
 # AddEditedChoiceListProvider.WhenToAdd.CompletedUnstable=ビルド成功時(Unstable含む)
 AddEditedChoiceListProvider.WhenToAdd.CompletedUnstable=\u30d3\u30eb\u30c9\u6210\u529f\u6642(Unstable\u542b\u3080)
+# ExtensibleChoiceParameterDefinition.EditableType.NoFilter=すべての選択肢を表示
+ExtensibleChoiceParameterDefinition.EditableType.NoFilter=\u3059\u3079\u3066\u306e\u9078\u629e\u80a2\u3092\u8868\u793a
+# ExtensibleChoiceParameterDefinition.EditableType.Filter=一致する選択肢のみ表示
+ExtensibleChoiceParameterDefinition.EditableType.Filter=\u4e00\u81f4\u3059\u308b\u9078\u629e\u80a2\u306e\u307f\u8868\u793a

--- a/src/main/resources/jp/ikedam/jenkins/plugins/taglib/form/staticSelect.jelly
+++ b/src/main/resources/jp/ikedam/jenkins/plugins/taglib/form/staticSelect.jelly
@@ -44,6 +44,9 @@ THE SOFTWARE.
     <st:attribute name="editable">
         specify whether this field is editable.
     </st:attribute>
+    <st:attribute name="editableType">
+        Candidates for input value when editable. NoFilter, Filter is available.
+    </st:attribute>
 </st:documentation>
 <j:scope>
     <j:set var="attrs" value="${attrs}" /> <!-- Required for prepareDatabinding -->
@@ -53,8 +56,8 @@ THE SOFTWARE.
     <m:select
         xmlns:m="jelly:hudson.util.jelly.MorphTagLibrary"
         ATTRIBUTES="${attrs}"
-        EXCEPT="name field items clazz editable value"
-        class="setting-input ${attrs.clazz} ${attrs.checkUrl!=null?'validated':''} ${attrs.editable?'staticCombobox':''}"
+        EXCEPT="name field items clazz editable editableType value"
+        class="setting-input ${attrs.clazz} ${attrs.checkUrl!=null?'validated':''} ${attrs.editable?'staticCombobox':''} editableType-${attrs.editableType}"
         autocomplete="off"
         name="${attrs.name ?: '_.'+attrs.field}">
         <j:forEach var="value" items="${attrs.items}">

--- a/src/main/resources/jp/ikedam/jenkins/plugins/taglib/form/staticSelect/staticCombobox.js
+++ b/src/main/resources/jp/ikedam/jenkins/plugins/taglib/form/staticSelect/staticCombobox.js
@@ -52,13 +52,21 @@ Behaviour.register({"SELECT.staticCombobox": function(e) {
     /*
      * Changes from the original 3:
      *   Original behavior: Show candidates that start with the current incomplete input.
-     *   Changed behavior : Show candidates that contain the current incomplete input.
+     *   Changed behavior : Change depends on the class name.
      */
-    var c = new ComboBox(e,function(value) {
-        return items.filter(function (item) {
-            return item.indexOf(value) > -1;
-        });
-    }, {});
+    // Show all the candidates, not concerning with the current incomplete input.
+    var filter = function(value) {
+        return items;
+    };
+    if ($(e).hasClassName("editableType-Filter")) {
+        // Show candidates that contain the current incomplete input.
+        filter = function(value) {
+            return items.filter(function (item) {
+                return item.indexOf(value) > -1;
+            });
+        };
+    }
+    var c = new ComboBox(e,filter,{});
     
     /*
      * Changes from the original 4:


### PR DESCRIPTION
to specify the filtering behavior in editable mode.

https://issues.jenkins-ci.org/browse/JENKINS-50315
https://issues.jenkins-ci.org/browse/JENKINS-22316

<img width="479" alt="choices_for_input_value" src="https://user-images.githubusercontent.com/3115961/39405224-7de1cca8-4bdc-11e8-8942-f2a660a9634a.png">

The default is "Display all choices" compatible with extensible-choice <= 1.4.2