### PR TITLE
[JENKINS-63786] Expose live choices to the remote API

### DIFF
--- a/src/main/java/jp/ikedam/jenkins/plugins/extensible_choice_parameter/ExtensibleChoiceParameterDefinition.java
+++ b/src/main/java/jp/ikedam/jenkins/plugins/extensible_choice_parameter/ExtensibleChoiceParameterDefinition.java
@@ -56,6 +56,7 @@ import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 
 import net.sf.json.JSONObject;
+import org.kohsuke.stapler.export.Exported;
 
 /**
  * Provides a choice parameter whose choices can be extended using Extension Points.
@@ -410,6 +411,7 @@ public class ExtensibleChoiceParameterDefinition extends SimpleParameterDefiniti
      * 
      * @return list of choices. never null.
      */
+    @Exported
     public List<String> getChoiceList()
     {
         ChoiceListProvider provider = getEnabledChoiceListProvider();


### PR DESCRIPTION
I'm using a Groovy script which is returning choices from a file based on labels of available Jenkins agents:
```
import hudson.model.labels.LabelAtom
import jenkins.model.Jenkins

def jenkins = Jenkins.get()
def workspace = "${jenkins.rootDir}/workspace/${project.name}"

return jenkins.computers
	.findAll { it.online }
	.collect { it.node.labelString }
	.collect { it.split('\\\\s+') }
	.flatten()
	.findAll { !it.empty }
	.collect { new File("${workspace}/configurations/${it}.txt") }
	.findAll { it.exists() }
	.collect { it.text.split('[\\\\r\\\\n]+') }
	.flatten()
```

With this changes the `choiceList` gets exposed to the Remote Access API.
You can check it at <JENKINS_URL>/job/<JOB_NAME>/api