### PR TITLE
[JENKINS-71683] Use script-security dependency from BOM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,8 +62,6 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>script-security</artifactId>
-      <!-- TODO SECURITY-2450 breaks jp.ikedam.jenkins.plugins.extensible_choice_parameter.SystemGroovyChoiceListProviderJenkinsTest#testConfiguration{1,2} -->
-      <version>1158.v7c1b_73a_69a_08</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/test/java/jp/ikedam/jenkins/plugins/extensible_choice_parameter/SystemGroovyChoiceListProviderJenkinsTest.java
+++ b/src/test/java/jp/ikedam/jenkins/plugins/extensible_choice_parameter/SystemGroovyChoiceListProviderJenkinsTest.java
@@ -528,6 +528,7 @@ public class SystemGroovyChoiceListProviderJenkinsTest {
         p.addProperty(new ParametersDefinitionProperty(def));
 
         j.configRoundtrip(p);
+        p.doReload(); // Workaround to drop transient properties in Script Security 1172.v35f6a_0b_8207e+
 
         j.assertEqualDataBoundBeans(
                 def, p.getProperty(ParametersDefinitionProperty.class).getParameterDefinition("test"));
@@ -553,6 +554,7 @@ public class SystemGroovyChoiceListProviderJenkinsTest {
         p.addProperty(new ParametersDefinitionProperty(def));
 
         j.configRoundtrip(p);
+        p.doReload(); // Workaround to drop transient properties in Script Security 1172.v35f6a_0b_8207e+
 
         j.assertEqualDataBoundBeans(
                 def, p.getProperty(ParametersDefinitionProperty.class).getParameterDefinition("test"));


### PR DESCRIPTION
Adapt test that didn't work with 1172.v35f6a_0b_8207e+

[JENKINS-71683](https://issues.jenkins.io/browse/JENKINS-71683)

### Testing done

Autotest; this is a test-only issue.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
