### PR TITLE
Adapt tests to jenkins.model.FullyNamed interface in 2.523

### DIFF
--- a/src/test/java/jp/ikedam/jenkins/plugins/extensible_choice_parameter/SystemGroovyChoiceListProviderJenkinsTest.java
+++ b/src/test/java/jp/ikedam/jenkins/plugins/extensible_choice_parameter/SystemGroovyChoiceListProviderJenkinsTest.java
@@ -411,6 +411,7 @@ public class SystemGroovyChoiceListProviderJenkinsTest {
     @Test
     public void testVariables() throws Exception {
         ScriptApproval.get().approveSignature("method hudson.model.Item getFullName");
+        ScriptApproval.get().approveSignature("method jenkins.model.FullyNamed getFullName");
         FreeStyleProject p = j.createFreeStyleProject();
         p.addProperty(new ParametersDefinitionProperty(new ExtensibleChoiceParameterDefinition(
                 "test", new SystemGroovyChoiceListProvider("[project.fullName]", null, true), false, "test")));
@@ -429,6 +430,7 @@ public class SystemGroovyChoiceListProviderJenkinsTest {
     @Test
     public void testProjectVariable() throws Exception {
         ScriptApproval.get().approveSignature("method hudson.model.Item getFullName");
+        ScriptApproval.get().approveSignature("method jenkins.model.FullyNamed getFullName");
         FreeStyleProject p = j.createFreeStyleProject();
         CaptureEnvironmentBuilder ceb = new CaptureEnvironmentBuilder();
         p.addProperty(new ParametersDefinitionProperty(new ExtensibleChoiceParameterDefinition(


### PR DESCRIPTION
## Adapt tests to jenkins.model.FullyNamed interface added in 2.523

Fix two tests that are blocking the Jenkins plugin BOM upgrade from Jenkins 2.522 to 2.523.  Blocked pull request is:

* https://github.com/jenkinsci/bom/pull/5519

New interface was added in Jenkins core pull request:

* https://github.com/jenkinsci/jenkins/pull/10827

Add a script approval for `jenkins.model.FullyNamed.getFullName()` since the tests already have a script approval for `hudson.model.Item.getFullName()`.  Keeps the tests consistent and allows the tests to pass with both older and newer Jenkins versions.

### Testing done

Confirmed that tests pass with Jenkins 2.523 and with default Jenkins version.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
