### PR TITLE
Use HTTP POST to test configure permission

### DIFF
--- a/src/test/java/jp/ikedam/jenkins/plugins/extensible_choice_parameter/SystemGroovyChoiceListProviderJenkinsTest.java
+++ b/src/test/java/jp/ikedam/jenkins/plugins/extensible_choice_parameter/SystemGroovyChoiceListProviderJenkinsTest.java
@@ -42,7 +42,9 @@ import java.util.Collections;
 import java.util.List;
 import jenkins.model.Jenkins;
 import org.htmlunit.FailingHttpStatusCodeException;
+import org.htmlunit.HttpMethod;
 import org.htmlunit.Page;
+import org.htmlunit.WebRequest;
 import org.htmlunit.html.DomElement;
 import org.htmlunit.html.HtmlPage;
 import org.htmlunit.html.HtmlSelect;
@@ -230,11 +232,11 @@ class SystemGroovyChoiceListProviderJenkinsTest {
         wc.login(configurer.getId());
 
         // missing Configure permission
-        page = wc.goTo(
-                p.getUrl() + descriptor.getDescriptorUrl() + "/fillDefaultChoiceItems/?script=" + properScript
-                        + "&sandbox=" + true + "&usePredefinedVariables=" + false,
-                null);
-        assertEquals(HttpServletResponse.SC_NOT_FOUND, page.getWebResponse().getStatusCode());
+        page = wc.getPage(new WebRequest(
+                wc.createCrumbedUrl(p.getUrl() + descriptor.getDescriptorUrl() + "/fillDefaultChoiceItems/?script="
+                        + properScript + "&sandbox=" + true + "&usePredefinedVariables=" + false),
+                HttpMethod.POST));
+        assertEquals(HttpServletResponse.SC_FORBIDDEN, page.getWebResponse().getStatusCode());
     }
 
     @Test
@@ -333,11 +335,11 @@ class SystemGroovyChoiceListProviderJenkinsTest {
         wc.login(configurer.getId());
 
         // missing Configure permission
-        page = wc.getPage(
-                p,
-                descriptor.getDescriptorUrl() + "/test/?script=" + properScript + "&sandbox=" + true
-                        + "&usePredefinedVariables=" + false);
-        assertEquals(HttpServletResponse.SC_NOT_FOUND, page.getWebResponse().getStatusCode());
+        page = wc.getPage(new WebRequest(
+                wc.createCrumbedUrl(p.getUrl() + descriptor.getDescriptorUrl() + "/test/?script=" + properScript
+                        + "&sandbox=" + true + "&usePredefinedVariables=" + false),
+                HttpMethod.POST));
+        assertEquals(HttpServletResponse.SC_FORBIDDEN, page.getWebResponse().getStatusCode());
     }
 
     @Test


### PR DESCRIPTION
## Use HTTP POST to test configure permission

Amends pull request:

* https://github.com/jenkinsci/extensible-choice-parameter-plugin/pull/127

The POST annotations added in the pull request reject the GET request that was previously used to check permissions.  That made the previous tests for permission execute a different path, but still pass.

Use an HTTP POST in the tests instead of HTTP GET.  Implementation idea borrowed from the `SubversionSCMTest` that uses a similar technique.

### Testing done

* Used the debugger to confirm that the permission code was executed before the POST annotation was added.  Confirmed that the permission code was not executed after the POST annotation was added.  Confirmed that this change to the test again executes the permission code.
* Removed the calls to `job.checkPermission(Item.CONFIGURE)` in the `SystemGroovyChoiceListProvider` methods for `doTest` and `doFillDefaultChoiceItems` and confirmed that the tests fail as they should

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
